### PR TITLE
Add critique head example

### DIFF
--- a/critique_head.py
+++ b/critique_head.py
@@ -1,0 +1,59 @@
+import torch
+import torch.nn as nn
+import hashlib
+
+class CritiqueHead(nn.Module):
+    """A simple critique head for analyzing transformer outputs."""
+
+    def __init__(self, hidden_size, num_labels=2):
+        super().__init__()
+        self.classifier = nn.Linear(hidden_size, num_labels)
+        self.softmax = nn.Softmax(dim=-1)
+
+    def forward(self, hidden_states):
+        logits = self.classifier(hidden_states)
+        probs = self.softmax(logits)
+        return probs
+
+
+def transformer_forward(prompt, memory):
+    """Placeholder transformer forward pass returning output text and latent state."""
+    # In practice this would use an actual transformer model.
+    latent_state = torch.randn(1, 768)
+    output_text = f"Generated text for: {prompt}"
+    return output_text, latent_state
+
+
+def get_state_hash(tensor):
+    """Generate a SHA-256 hash for a tensor state."""
+    data = tensor.detach().cpu().numpy().tobytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def reconcile(draft, critique):
+    """Combine draft output with critique feedback."""
+    return draft + "\nCRITIQUE:" + critique
+
+
+def rawai_generate(user_input, memory=None):
+    """Generate text with a self-critique phase and metadata."""
+    draft_output, latent_state = transformer_forward(user_input, memory)
+
+    critique_prompt = (
+        "CRITIQUE PROTOCOL ACTIVATED:\n" f"Subject: '{draft_output}'\n" "Task: Identify logical errors or contradictions."
+    )
+    critique, _ = transformer_forward(critique_prompt, latent_state)
+
+    refined_output = reconcile(draft_output, critique)
+
+    metadata = {
+        "state_hash": get_state_hash(latent_state),
+    }
+    return refined_output, metadata
+
+
+# Example usage skeleton
+if __name__ == "__main__":
+    output, meta = rawai_generate("Hello world")
+    print(output)
+    print(meta)


### PR DESCRIPTION
## Summary
- show a sample `CritiqueHead` module in PyTorch
- implement `rawai_generate` with a placeholder self-critique workflow

## Testing
- `python critique_head.py`

------
https://chatgpt.com/codex/tasks/task_e_68462504f0188324bc30b320d87cdd12